### PR TITLE
fixes duplicate ads on single post and video pages

### DIFF
--- a/discussionwp-child/single-post.php
+++ b/discussionwp-child/single-post.php
@@ -17,50 +17,39 @@
     $thumb_image_size = '150';
     $excerpt_length = '12';
     ?>
-<div class="mkd-two-columns-75-25  mkd-content-has-sidebar clearfix">
-    <?php if (has_post_thumbnail()) { ?>
-            <div class="mkd-blog-holder mkd-column1 mkd-blog-single mkd-fsp-blog-holder">
-                <div class="mkd-column-inner">
-                    <?php ?>
-                    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-                        <div class="mkd-post-content">
-                            <?php if (has_post_thumbnail()) { ?>
-                                <div class="mkd-post-image-area">
-                                    <?php discussion_post_info_category(array('category' => 'no')) ?>
-                                    <?php discussion_get_module_template_part('templates/single/parts/image', 'blog'); ?>
-                                </div>
-                            <?php } ?>
-                        </div>
-                        <?php do_action('discussion_before_blog_article_closed_tag'); ?>
-                    </article>
-                    <div class="single-article-fsp-info">
-                        <article>
-                            <div class="mkd-post-info">
-                                <?php
-                                discussion_post_info(array(
-                                    'date' => $display_date,
-                                    'category_singlepost' => $display_category_singlepost
-                                ))
-                                ?>
-        <!--                        <div class="mkd-post-fsp-savestories">
-                                <?php
-                                   //customized_saved_stories();
-                                ?>
-                                </div>-->
+    <div class="mkd-two-columns-75-25 mkd-content-has-sidebar clearfix">
+        <div class="mkd-blog-holder mkd-column1 mkd-content-left-from-sidebar mkd-blog-single mkd-fsp-blog-holder">
+            <div class="mkd-column-inner">
+                <?php ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                    <div class="mkd-post-content">
+                        <?php if (has_post_thumbnail()) { ?>
+                            <div class="mkd-post-image-area">
+                                <?php discussion_post_info_category(array('category' => 'no')) ?>
+                                <?php discussion_get_module_template_part('templates/single/parts/image', 'blog'); ?>
                             </div>
-                        </article>
+                        <?php } ?>
                     </div>
+                    <?php do_action('discussion_before_blog_article_closed_tag'); ?>
+                </article>
+                <div class="single-article-fsp-info">
+                    <article>
+                        <div class="mkd-post-info">
+                            <?php
+                            discussion_post_info(array(
+                                'date' => $display_date,
+                                'category_singlepost' => $display_category_singlepost
+                            ))
+                            ?>
+                            <!--<div class="mkd-post-fsp-savestories">
+                            <?php
+                               //customized_saved_stories();
+                            ?>
+                            </div>-->
+                        </div>
+                    </article>
                 </div>
             </div>
-    <?php } ?>
-            <div class="mkd-column2 egw-show-for-large-up">
-                <div class="mkd-column-inner">
-                    <aside class="mkd-sidebar" style="transform: translateY(0px);">
-                        <?php get_template_part('sidebar/template-sidebar-single'); ?>
-                    </aside>
-                </div>
-            </div>
-            <div class="mkd-column1 mkd-content-left-from-sidebar">
             <div class="mkd-column-inner">
                 <div class="mkd-blog-holder mkd-blog-single">
                     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -156,12 +145,12 @@
                     //discussion_get_single_related_posts();
                     ?>
                     <?php if (function_exists('the_tags')) { ?>
-                        <div class="mkd-single-tags-holder">
-                            <span class="mkd-single-tags-title"><strong>Tags: </strong></span>
-                            <div class="mkd-tags">
-                                <?php the_tags('', ' ', ''); ?><br />
-                            </div>
+                    <div class="mkd-single-tags-holder">
+                        <span class="mkd-single-tags-title"><strong>Tags: </strong></span>
+                        <div class="mkd-tags">
+                            <?php the_tags('', ' ', ''); ?><br />
                         </div>
+                    </div>
                     <?php } ?>
                     <?php get_template_part('sidebar/template-ads-mobile'); ?>
                     <div class="fsp-recommended-stories-cont">
@@ -176,7 +165,7 @@
                 </div>
             </div>
         </div>
-        <div class="mkd-column2 egw-hide-for-large-up">
+        <div class="mkd-column2">
             <div class="mkd-column-inner">
                 <aside class="mkd-sidebar" style="transform: translateY(0px);">
                     <?php get_template_part('sidebar/template-sidebar-single'); ?>

--- a/discussionwp-child/single-videos.php
+++ b/discussionwp-child/single-videos.php
@@ -12,8 +12,8 @@
     ?>
 
 
-    <div class="mkd-two-columns-75-25  mkd-content-has-sidebar clearfix">
-        <div class="mkd-blog-holder mkd-column1 mkd-blog-single mkd-fsp-blog-holder">
+    <div class="mkd-two-columns-75-25 mkd-content-has-sidebar clearfix">
+        <div class="mkd-blog-holder mkd-column1 mkd-content-left-from-sidebar mkd-blog-single mkd-fsp-blog-holder">
             <div class="mkd-column-inner">
                 <?php ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -42,16 +42,6 @@
                     </article>
                 </div>
             </div>
-        </div>
-
-        <div class="mkd-column2 egw-show-for-large-up">
-            <div class="mkd-column-inner">
-                <aside class="mkd-sidebar" style="transform: translateY(0px);">
-                    <?php get_template_part('sidebar/template-sidebar-single'); ?>
-                </aside>
-            </div>
-        </div>
-        <div class="mkd-column1 mkd-content-left-from-sidebar">
             <div class="mkd-column-inner">
                 <div class="mkd-blog-holder mkd-blog-single">
                     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -139,7 +129,7 @@
                 ?>
             </div>
         </div>
-        <div class="mkd-column2 egw-hide-for-large-up">
+        <div class="mkd-column2">
             <div class="mkd-column-inner">
                 <aside class="mkd-sidebar" style="transform: translateY(0px);">
                     <?php get_template_part('sidebar/template-sidebar-single'); ?>

--- a/village-child/single-post.php
+++ b/village-child/single-post.php
@@ -17,50 +17,39 @@
     $thumb_image_size = '150';
     $excerpt_length = '12';
     ?>
-<div class="mkd-two-columns-75-25  mkd-content-has-sidebar clearfix">
-    <?php if (has_post_thumbnail()) { ?>
-            <div class="mkd-blog-holder mkd-column1 mkd-blog-single mkd-fsp-blog-holder">
-                <div class="mkd-column-inner">
-                    <?php ?>
-                    <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
-                        <div class="mkd-post-content">
-                            <?php if (has_post_thumbnail()) { ?>
-                                <div class="mkd-post-image-area">
-                                    <?php discussion_post_info_category(array('category' => 'no')) ?>
-                                    <?php discussion_get_module_template_part('templates/single/parts/image', 'blog'); ?>
-                                </div>
-                            <?php } ?>
-                        </div>
-                        <?php do_action('discussion_before_blog_article_closed_tag'); ?>
-                    </article>
-                    <div class="single-article-fsp-info">
-                        <article>
-                            <div class="mkd-post-info">
-                                <?php
-                                discussion_post_info(array(
-                                    'date' => $display_date,
-                                    'category_singlepost' => $display_category_singlepost
-                                ))
-                                ?>
-                                <div class="mkd-post-fsp-savestories">
-                                <?php
-                                   customized_saved_stories();
-                                ?>
-                                </div>
+    <div class="mkd-two-columns-75-25 mkd-content-has-sidebar clearfix">
+        <div class="mkd-blog-holder mkd-column1 mkd-content-left-from-sidebar mkd-blog-single mkd-fsp-blog-holder">
+            <div class="mkd-column-inner">
+                <?php ?>
+                <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                    <div class="mkd-post-content">
+                        <?php if (has_post_thumbnail()) { ?>
+                            <div class="mkd-post-image-area">
+                                <?php discussion_post_info_category(array('category' => 'no')) ?>
+                                <?php discussion_get_module_template_part('templates/single/parts/image', 'blog'); ?>
                             </div>
-                        </article>
+                        <?php } ?>
                     </div>
+                    <?php do_action('discussion_before_blog_article_closed_tag'); ?>
+                </article>
+                <div class="single-article-fsp-info">
+                    <article>
+                        <div class="mkd-post-info">
+                            <?php
+                            discussion_post_info(array(
+                                'date' => $display_date,
+                                'category_singlepost' => $display_category_singlepost
+                            ))
+                            ?>
+                            <div class="mkd-post-fsp-savestories">
+                            <?php
+                               customized_saved_stories();
+                            ?>
+                            </div>
+                        </div>
+                    </article>
                 </div>
             </div>
-    <?php } ?>
-            <div class="mkd-column2 egw-show-for-large-up">
-                <div class="mkd-column-inner">
-                    <aside class="mkd-sidebar" style="transform: translateY(0px);">
-                        <?php get_template_part('sidebar/template-sidebar-single'); ?>
-                    </aside>
-                </div>
-            </div>
-            <div class="mkd-column1 mkd-content-left-from-sidebar">
             <div class="mkd-column-inner">
                 <div class="mkd-blog-holder mkd-blog-single">
                     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -176,7 +165,7 @@
                 </div>
             </div>
         </div>
-        <div class="mkd-column2 egw-hide-for-large-up">
+        <div class="mkd-column2">
             <div class="mkd-column-inner">
                 <aside class="mkd-sidebar" style="transform: translateY(0px);">
                     <?php get_template_part('sidebar/template-sidebar-single'); ?>

--- a/village-child/single-videos.php
+++ b/village-child/single-videos.php
@@ -12,8 +12,8 @@
     ?>
 
 
-    <div class="mkd-two-columns-75-25  mkd-content-has-sidebar clearfix">
-        <div class="mkd-blog-holder mkd-column1 mkd-blog-single mkd-fsp-blog-holder">
+    <div class="mkd-two-columns-75-25 mkd-content-has-sidebar clearfix">
+        <div class="mkd-blog-holder mkd-column1 mkd-content-left-from-sidebar mkd-blog-single mkd-fsp-blog-holder">
             <div class="mkd-column-inner">
                 <?php ?>
                 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -42,16 +42,6 @@
                     </article>
                 </div>
             </div>
-        </div>
-
-        <div class="mkd-column2 egw-show-for-large-up">
-            <div class="mkd-column-inner">
-                <aside class="mkd-sidebar" style="transform: translateY(0px);">
-                    <?php get_template_part('sidebar/template-sidebar-single'); ?>
-                </aside>
-            </div>
-        </div>
-        <div class="mkd-column1 mkd-content-left-from-sidebar">
             <div class="mkd-column-inner">
                 <div class="mkd-blog-holder mkd-blog-single">
                     <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -139,7 +129,7 @@
                 ?>
             </div>
         </div>
-        <div class="mkd-column2 egw-hide-for-large-up">
+        <div class="mkd-column2">
             <div class="mkd-column-inner">
                 <aside class="mkd-sidebar" style="transform: translateY(0px);">
                     <?php get_template_part('sidebar/template-sidebar-single'); ?>


### PR DESCRIPTION
These fixes revise the layouts in both discussionwp-child and village-child to place the header image AND article content in the same "containers" of each template so that they will collapse correctly on phone and tablet views, without the need of the added egw-show-for-large-up CSS classes. @adamdoe 